### PR TITLE
fix: 修复lego注册acme次数限制问题

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -71,8 +71,7 @@ func (conf *Config) LoadOptions() {
 		log.Fatalf("读取配置文件 %s 出错: %s", conf.Path, err.Error())
 	}
 
-	// 根据配置更新证书更新提前过期时间
-	expiredEarlyTime = time.Hour * 24 * time.Duration(max(15, conf.Acme.ExpiredEarly))
+	conf.setExpiredEarlyTime()
 
 	log.Debugf("配置文件: %s", conf)
 }
@@ -97,10 +96,16 @@ func (conf *Config) LoadOptionsFromEnv() {
 		} else {
 			conf.Acme.ExpiredEarly = valueInt
 			log.Debugf("set acme (expired early) from env: %d", valueInt)
+			conf.setExpiredEarlyTime()
 		}
 	}
 
 	log.Debugf("配置文件: %s", conf)
+}
+
+func (conf *Config) setExpiredEarlyTime() {
+	// 根据配置更新证书更新提前过期时间
+	expiredEarlyTime = time.Hour * 24 * time.Duration(max(15, conf.Acme.ExpiredEarly))
 }
 
 func GetExpiredEarlyTime() time.Duration {

--- a/core/cert.go
+++ b/core/cert.go
@@ -41,6 +41,10 @@ func New(conf *config.Config) *Manager {
 	}
 }
 
+func (m *Manager) Stop() {
+	m.lego.Stop()
+}
+
 func (m *Manager) Run() {
 	if m.running {
 		return

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ func main() {
 	for {
 		select {
 		case <-sig:
+			m.Stop()
 			tick.Stop()
 			log.Infof("Exit.")
 			os.Exit(0)

--- a/pkg/acme/lego.go
+++ b/pkg/acme/lego.go
@@ -142,6 +142,13 @@ func (lg *LegoService) Obtain(bucket string, domain string, ossClient *oss.Clien
 	return cert, nil
 }
 
+func (lg *LegoService) Stop() {
+	err := lg.client.Registration.DeleteRegistration()
+	if err != nil {
+		log.Errorf(err.Error())
+	}
+}
+
 func (lg *LegoService) save(cert *certificate.Resource) {
 	lg.cmux.Lock()
 	defer lg.cmux.Unlock()


### PR DESCRIPTION
修复IP限制账号注册次数问题：https://letsencrypt.org/docs/too-many-registrations-for-this-ip/
- 开发使用staging地址
- 关闭删除注册
