### PR TITLE
feat: 优化启动与调度日志，启动后立即巡检

### DIFF
--- a/internal/cert/auto_cert.go
+++ b/internal/cert/auto_cert.go
@@ -3,6 +3,7 @@ package cert
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -13,6 +14,11 @@ import (
 	"github.com/nekoimi/oss-auto-cert/internal/config"
 	"github.com/nekoimi/oss-auto-cert/pkg/webhook"
 )
+
+// ScheduleInterval 证书巡检定时周期，与 ScheduleRun 中 Ticker 间隔一致。
+const ScheduleInterval = 6 * time.Hour
+
+const maxBucketNamesInInfoLog = 5
 
 type AutoCert struct {
 	ctx           context.Context
@@ -47,9 +53,17 @@ func NewAutoCert(ctx context.Context, conf *config.Config) (*AutoCert, error) {
 	if len(c.buckets) <= 0 {
 		log.Warnf("OSS存储Bucket配置为空!")
 	} else {
+		names := make([]string, 0, len(c.buckets))
 		for _, b := range c.buckets {
+			names = append(names, b.Name)
 			log.Debugf("Bucket开启监测: %s => %s", b.Name, b.Endpoint)
 		}
+		summary := strings.Join(names, ", ")
+		if len(c.buckets) > maxBucketNamesInInfoLog {
+			summary = strings.Join(names[:maxBucketNamesInInfoLog], ", ") +
+				fmt.Sprintf(" 等共 %d 个", len(c.buckets))
+		}
+		log.Infof("已加载 %d 个待监测 Bucket: %s", len(c.buckets), summary)
 	}
 
 	if conf.Webhook != "" {
@@ -72,6 +86,11 @@ func (c *AutoCert) withMessageHandle(messageHandle func(message string)) {
 }
 
 func (c *AutoCert) ScheduleRun() {
+	log.Infof(
+		"定时调度已启动：证书检查间隔为 %s；启动后将立即执行一次巡检，此后按间隔重复执行",
+		ScheduleInterval,
+	)
+
 	go func() {
 		for {
 			select {
@@ -86,7 +105,9 @@ func (c *AutoCert) ScheduleRun() {
 	}()
 
 	go func() {
-		tick := time.NewTicker(6 * time.Hour)
+		go c.run()
+		tick := time.NewTicker(ScheduleInterval)
+		defer tick.Stop()
 		for {
 			select {
 			case <-c.ctx.Done():
@@ -111,6 +132,10 @@ func (c *AutoCert) run() {
 	defer func() {
 		c.running.Store(false)
 	}()
+
+	if len(c.buckets) > 0 {
+		log.Infof("开始执行证书巡检，共 %d 个 Bucket", len(c.buckets))
+	}
 
 	for _, bucket := range c.buckets {
 		log.Debugf("开始检测Bucket: %s ...", bucket.Name)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/charmbracelet/log"
@@ -44,6 +45,27 @@ func main() {
 	}
 
 	m.ScheduleRun()
+
+	log.Infof("oss-auto-cert 服务已成功启动，进程常驻运行中")
+	log.Infof("配置文件路径: %s", conf.Path)
+	switch n := len(conf.Buckets); {
+	case n == 0:
+		log.Warnf("当前未配置任何 Bucket，请检查配置文件中的 buckets 段")
+	case n <= 5:
+		names := make([]string, 0, n)
+		for _, b := range conf.Buckets {
+			names = append(names, b.Name)
+		}
+		log.Infof("监控 Bucket（%d）: %s", n, strings.Join(names, ", "))
+	default:
+		names := make([]string, 0, 5)
+		for i := 0; i < 5; i++ {
+			names = append(names, conf.Buckets[i].Name)
+		}
+		log.Infof("监控 Bucket 共 %d 个: %s 等", n, strings.Join(names, ", "))
+	}
+	log.Infof("调度说明: 启动时已触发一次巡检；之后每隔 %s 自动巡检一次", cert.ScheduleInterval)
+	log.Infof("退出方式: 发送 SIGINT、SIGTERM 或 SIGQUIT 可优雅退出")
 
 	// wait
 	select {


### PR DESCRIPTION
- 导出 ScheduleInterval 常量，统一间隔说明与 Ticker
- NewAutoCert 与 main 输出 Info 级 Bucket 与配置摘要
- ScheduleRun 同步打印调度说明，启动后先执行一次 run()
- run() 开始时输出巡检 Info，便于确认进程未卡住

Made-with: Cursor