### PR TITLE
fix(docker): 对齐 Go 1.25、修正 AS 大小写，依赖分层缓存

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM golang:1.23-alpine as builder
+FROM golang:1.25-alpine AS builder
 
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
 
 WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+
 COPY . .
-RUN go install
 RUN go build --ldflags "-extldflags -static -s -w" -o oss-auto-cert main.go
 
 FROM alpine:latest


### PR DESCRIPTION
- 使用 golang:1.25-alpine 匹配 go.mod
- FROM ... AS builder 消除 BuildKit FromAsCasing 警告
- 移除无效 go install；先 go mod download 再构建以利用缓存

Made-with: Cursor